### PR TITLE
Fix 'Not a scoop shim' in scripts

### DIFF
--- a/scripts/install-python-package.ps1
+++ b/scripts/install-python-package.ps1
@@ -14,7 +14,7 @@
 #   -b, --branch <branch>     Git repository branch
 #   -c, --clone-dir <name>    Git clone directory name
 
-$scoop_lib = "$(Split-Path (Split-Path (scoop which scoop)))\lib"
+$scoop_lib = Join-Path (scoop prefix scoop) lib
 . "$scoop_lib\getopt.ps1"
 . "$scoop_lib\help.ps1"
 

--- a/scripts/migrate-python-packages.ps1
+++ b/scripts/migrate-python-packages.ps1
@@ -15,7 +15,7 @@
 #   -q, --quiet               Do not write package names to console
 #   -v, --verbose             Display all output
 
-$scoop_lib = "$(Split-Path (Split-Path (scoop which scoop)))\lib"
+$scoop_lib = Join-Path (scoop prefix scoop) lib
 . "$scoop_lib\buckets.ps1"
 . "$scoop_lib\getopt.ps1"
 . "$scoop_lib\help.ps1"

--- a/scripts/uninstall-python-package.ps1
+++ b/scripts/uninstall-python-package.ps1
@@ -9,7 +9,7 @@
 #   -d, --dir <dir>           The setup directory
 #   -m, --match <pattern>     Pattern that specifies which files to remove
 
-$scoop_lib = "$(Split-Path (Split-Path (scoop which scoop)))\lib"
+$scoop_lib = Join-Path (scoop prefix scoop) lib
 . "$scoop_lib\getopt.ps1"
 . "$scoop_lib\help.ps1"
 


### PR DESCRIPTION
I was getting errors while installing any manifest from this bucket. Tracked it down to the line `$scoop_lib = "$(Split-Path (Split-Path (scoop which scoop)))\lib"` in the scripts for installing/uninstalling etc. Looks like `scoop which scoop` doesn't work anymore so I fixed it!